### PR TITLE
New version of YAML does not allow duplicate values of key value pairs

### DIFF
--- a/YAML/advanceDatatypes.yaml
+++ b/YAML/advanceDatatypes.yaml
@@ -38,16 +38,6 @@ role:
 name: Kunal Kushwaha
 role: { age: 78, job: student}
 
-# pairs: keys may have duplicate values
-# !!pairs
-
-pair example: !!pairs
- - job: student
- - job: teacher
-
-# same as
-pair example: !!pairs [job: student, job: teacher]
-# this will be an array of hashtables
 
 # !!set will allow you to have unique values
 names: !!set


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1oZ1tTIXZuLERXpQWkTmIYki9ZTzmA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=NEUU74q)
https://www.drupal.org/project/upgrade_status/issues/3256376#:~:text=Duplicate%20keys%20in%20YAML%20files,newer%20version%20throws%20an%20exception.

Please refer to this article.
thus the section of code for duplicate values of key-value pairs should be removed.