### PR TITLE
removed the Expired link from README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
  
 - <a href="https://www.youtube.com/playlist?list=PL9gnSGHSqcnoqBXdMwUTRod4Gi3eac2Ak" style="background-color:#FFFFFF;color:#000000;text-decoration:none">📂 Complete playlist</a>
 
-- <a href="https://www.youtube.com/playlist?list=PL9gnSGHSqcnojMGw6LDTkjs7avZ0f83Ap" style="background-color:#FFFFFF;color:#000000;text-decoration:none">🛠 DevOps tools playlist</a> 
 
 ## Connect with me
   <a href="https://twitter.com/kunalstwt">


### PR DESCRIPTION
Removed the 'Devops Tools playlist' as it cant be found on the internet.
looks like that the playlist is either removed or it is merged in the course playlist itself.